### PR TITLE
feat: NXT 거래소 주문/취소 엔드포인트 분기 추가

### DIFF
--- a/pydbfi/api.py
+++ b/pydbfi/api.py
@@ -93,6 +93,7 @@ class DomesticAPI(BaseAPI):
         credit_type: str = "000",  # 보통
         loan_date: str = "00000000",  # 일반주문
         order_condition: str = "0",  # 없음
+        use_nxt: bool = False,
     ) -> Dict[str, Any]:
         order_request = DomesticOrderRequest(
             stock_code=stock_code,
@@ -104,9 +105,8 @@ class DomesticAPI(BaseAPI):
             loan_date=loan_date,
             order_condition=order_condition,
         )
-        return self._execute_service(
-            self._get_trading_service, "place_order", request=order_request
-        )
+        service = self._get_trading_service()
+        return service.place_order(order_request, use_nxt=use_nxt)
 
     def sell(
         self,
@@ -117,6 +117,7 @@ class DomesticAPI(BaseAPI):
         credit_type: str = "000",  # 보통
         loan_date: str = "00000000",  # 일반주문
         order_condition: str = "0",  # 없음
+        use_nxt: bool = False,
     ) -> Dict[str, Any]:
         order_request = DomesticOrderRequest(
             stock_code=stock_code,
@@ -128,17 +129,15 @@ class DomesticAPI(BaseAPI):
             loan_date=loan_date,
             order_condition=order_condition,
         )
-        return self._execute_service(
-            self._get_trading_service, "place_order", request=order_request
-        )
+        service = self._get_trading_service()
+        return service.place_order(order_request, use_nxt=use_nxt)
 
-    def cancel(self, order_no: int, stock_code: str, quantity: int) -> Dict[str, Any]:
+    def cancel(self, order_no: int, stock_code: str, quantity: int, use_nxt: bool = False) -> Dict[str, Any]:
         cancel_request = DomesticCancelOrderRequest(
             original_order_no=order_no, stock_code=stock_code, quantity=quantity
         )
-        return self._execute_service(
-            self._get_trading_service, "cancel_order", request=cancel_request
-        )
+        service = self._get_trading_service()
+        return service.cancel_order(cancel_request, use_nxt=use_nxt)
 
     def get_transaction_history(
         self,

--- a/pydbfi/service/trading.py
+++ b/pydbfi/service/trading.py
@@ -6,16 +6,16 @@ from ..service.common.interfaces import ITradingService
 
 class DomesticTradingService(BaseService, ITradingService):
     def place_order(
-        self, order_request: DomesticOrderRequest, **kwargs
+        self, order_request: DomesticOrderRequest, use_nxt: bool = False, **kwargs
     ) -> Dict[str, Any]:
-        endpoint = "/api/v1/trading/kr-stock/order"
+        endpoint = "/api/v1/trading/kr-stock/order-nxt" if use_nxt else "/api/v1/trading/kr-stock/order"
         data = order_request.to_request_data()
         return self._request("POST", endpoint, data=data, **kwargs)
 
     def cancel_order(
-        self, cancel_request: DomesticCancelOrderRequest, **kwargs
+        self, cancel_request: DomesticCancelOrderRequest, use_nxt: bool = False, **kwargs
     ) -> Dict[str, Any]:
-        endpoint = "/api/v1/trading/kr-stock/order-cancel"
+        endpoint = "/api/v1/trading/kr-stock/order-cancel-nxt" if use_nxt else "/api/v1/trading/kr-stock/order-cancel"
         data = cancel_request.to_request_data()
         return self._request("POST", endpoint, data=data, **kwargs)
 


### PR DESCRIPTION
## Summary
- `DomesticTradingService.place_order/cancel_order`에 `use_nxt: bool` 파라미터 추가
- `use_nxt=True` 시 `/order-nxt`, `/order-cancel-nxt` 엔드포인트로 라우팅
- `DomesticAPI.buy/sell/cancel`에서 `use_nxt` kwargs 전달 지원
- Request Body 스키마는 기존 KRX 주문과 동일 (API 문서 검증 완료)

## Test plan
- [x] AFTER 세션에서 DB증권 NXT 주문 성공 확인 (005930, 000660)
- [x] `use_nxt=False` (기본값) 시 기존 KRX 엔드포인트 동작 유지
- [x] `DBFI.buy/sell/cancel` → `**kwargs` 자동 전달 확인 (main.py 변경 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)